### PR TITLE
fix(with-next): make the Netlify config work out-of-the-box

### DIFF
--- a/with-next/.env.sample
+++ b/with-next/.env.sample
@@ -1,2 +1,2 @@
-NEXT_PUBLIC_STEPZEN_ENDPOINT=https://your_account.stepzen.net/starter/nextjs/__graphql
+NEXT_PUBLIC_STEPZEN_ENDPOINT=https://your_account.stepzen.net/api/with-next/__graphql
 NEXT_PUBLIC_STEPZEN_API_KEY=

--- a/with-next/netlify.toml
+++ b/with-next/netlify.toml
@@ -3,7 +3,7 @@
   publish = "out"
 
 [[plugins]]
-  package = "/plugins/netlify-plugin-stepzen"
+  package = "netlify-plugin-stepzen"
 
 [template]
   incoming-hooks = ["StepZen"]

--- a/with-next/netlify.toml
+++ b/with-next/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   command = "npm run build"
-  publish = "out"
+  publish = ".next"
 
 [[plugins]]
   package = "netlify-plugin-stepzen"

--- a/with-next/netlify.toml
+++ b/with-next/netlify.toml
@@ -5,15 +5,15 @@
 [[plugins]]
   package = "netlify-plugin-stepzen"
 
+[context.production.environment]
+  STEPZEN_FOLDER = "api"
+  STEPZEN_NAME = "with-next"
+
 [template]
   incoming-hooks = ["StepZen"]
 
 [template.environment]
+  NEXT_PUBLIC_STEPZEN_API_KEY = "Copy and paste your StepZen API key here."
+  NEXT_PUBLIC_STEPZEN_ENDPOINT = "Copy and paste your API endpoint here."
   STEPZEN_ACCOUNT = "Add your StepZen account name"  
-  NEXT_PUBLIC_STEPZEN_ACCOUNT = "Copy and paste your account here."
-  STEPZEN_API_KEY = "Add your StepZen admin key"
-  NEXT_PUBLIC_STEPZEN_API_KEY = "Copy and paste your admin key here."
-  STEPZEN_NAME = "Name your endpoint. Defaults to endpoint"
-  NEXT_PUBLIC_STEPZEN_NAME = "Copy and paste your endpoint here."
-  STEPZEN_FOLDER = "Name your folder. Defaults to netlify"
-  NEXT_PUBLIC_STEPZEN_FOLDER = "Copy and paste your folder here."
+  STEPZEN_ADMIN_KEY = "Add your StepZen admin key"


### PR DESCRIPTION
- correct the stepzen endpoint URL in the .env template
- correct the StepZen Netlify plugin name
- correct the published folder in Netlify config
- correct the environment vars in Netlify config

With these changes the example can be deployed to Netlify out-of-the-box. Without them deployment fails.