### PR TITLE
housekeeping: remove stepzen config files

### DIFF
--- a/with-airtable-prismjs-axios/stepzen.config.json
+++ b/with-airtable-prismjs-axios/stepzen.config.json
@@ -1,4 +1,0 @@
-{
-  "endpoint": "api/with-airtable-prismjs-axios",
-  "root": "stepzen"
-}

--- a/with-gatsby/stepzen.config.json
+++ b/with-gatsby/stepzen.config.json
@@ -1,4 +1,0 @@
-{
-  "endpoint": "api/with-gatsby",
-  "root": "stepzen"
-}

--- a/with-google-analytics/stepzen.config.json
+++ b/with-google-analytics/stepzen.config.json
@@ -1,4 +1,0 @@
-{
-  "endpoint": "api/with-google-analytics",
-  "root": "stepzen"
-}

--- a/with-google-login-faunadb/stepzen.config.json
+++ b/with-google-login-faunadb/stepzen.config.json
@@ -1,4 +1,0 @@
-{
-  "endpoint": "api/with-google-login-faunadb",
-  "root": "stepzen"
-}

--- a/with-harperdb/stepzen.config.json
+++ b/with-harperdb/stepzen.config.json
@@ -1,3 +1,0 @@
-{
-  "endpoint": "api/with-harperdb"
-}

--- a/with-mongodb-atlas/stepzen.config.json
+++ b/with-mongodb-atlas/stepzen.config.json
@@ -1,4 +1,0 @@
-{
-  "endpoint": "api/with-mongodb-atlas",
-  "root": "stepzen"
-}

--- a/with-mysql/stepzen.config.json
+++ b/with-mysql/stepzen.config.json
@@ -1,3 +1,0 @@
-{
-  "endpoint": "api/with-mysql"
-}

--- a/with-next/stepzen.config.json
+++ b/with-next/stepzen.config.json
@@ -1,4 +1,0 @@
-{
-  "endpoint": "api/with-next",
-  "root": "stepzen"
-}

--- a/with-planetscale/stepzen.config.json
+++ b/with-planetscale/stepzen.config.json
@@ -1,3 +1,0 @@
-{
-  "endpoint": "api/with-planetscale"
-}

--- a/with-postgresql/stepzen.config.json
+++ b/with-postgresql/stepzen.config.json
@@ -1,3 +1,0 @@
-{
-  "endpoint": "api/with-postgresql"
-}

--- a/with-python/stepzen.config.json
+++ b/with-python/stepzen.config.json
@@ -1,4 +1,0 @@
-{
-  "endpoint": "api/with-python",
-  "root": "stepzen"
-}

--- a/with-react-native/stepzen.config.json
+++ b/with-react-native/stepzen.config.json
@@ -1,4 +1,0 @@
-{
-  "endpoint": "api/with-react-native",
-  "root": "stepzen"
-}

--- a/with-rest/stepzen.config.json
+++ b/with-rest/stepzen.config.json
@@ -1,4 +1,0 @@
-{
-  "endpoint": "api/with-rest",
-  "root": "stepzen"
-}

--- a/with-shopify-agilitycms/stepzen.config.json
+++ b/with-shopify-agilitycms/stepzen.config.json
@@ -1,4 +1,0 @@
-{
-  "endpoint": "api/with-shopify-agilitycms",
-  "root": "stepzen"
-}

--- a/with-spectaql/stepzen.config.json
+++ b/with-spectaql/stepzen.config.json
@@ -1,4 +1,0 @@
-{
-  "endpoint": "api/with-spectaql",
-  "root": "stepzen"
-}

--- a/with-sveltekit/stepzen.config.json
+++ b/with-sveltekit/stepzen.config.json
@@ -1,4 +1,0 @@
-{
-  "endpoint": "api/with-sveltekit",
-  "root": "stepzen"
-}


### PR DESCRIPTION
remove `stepzen.config.json` from samples so user's auto-gen endpoints will replace them. 
