### PR TITLE
Use plaintext query in sequence

### DIFF
--- a/with-openai/blog/extensions.graphql
+++ b/with-openai/blog/extensions.graphql
@@ -7,12 +7,12 @@ extend type BlogPost {
   summary: TextCompletion
     @materializer(
       query: "summary"
-      arguments: [{ name: "fulltext", field: "plaintext" }]
+      arguments: [{ name: "htmltext", field: "encoded" }]
     )
   image: GenerationResult
     @materializer(
       query: "image"
-      arguments: [{ name: "fulltext", field: "plaintext" }]
+      arguments: [{ name: "htmltext", field: "encoded" }]
     )
 }
 
@@ -47,9 +47,10 @@ type Query {
       """
     )
 
-  summary(fulltext: String): TextCompletion
+  summary(htmltext: String): TextCompletion
     @sequence(
       steps: [
+        { query: "plaintext" }
         { query: "_summaryPrompt" }
         {
           query: "textCompletion"
@@ -82,9 +83,10 @@ type Query {
       """
     )
 
-  image(fulltext: String): GenerationResult
+  image(htmltext: String): GenerationResult
     @sequence(
       steps: [
+        { query: "plaintext" }
         { query: "_imagePromptPrompt" }
         {
           query: "textCompletion"


### PR DESCRIPTION
@vlukashov the field `plaintext` in the extended type `BlogPost` kept returning `undefined` when using it in `@materializer`, while it was available as a field when querying the `BlogPost` type directly. I'm assuming at the time `@materializer` runs this field is not (yet) available, might be coming from cache and is undefined when there's no cached value available, or some race condition happens. Have a look in the new year! 